### PR TITLE
add escape= and quoteall= parameters to CSVConnectionParameters

### DIFF
--- a/drivers/src/java/scriptella/driver/csv/CsvConnection.java
+++ b/drivers/src/java/scriptella/driver/csv/CsvConnection.java
@@ -71,6 +71,13 @@ public class CsvConnection extends AbstractTextConnection {
      */
     public static final String HEADERS = "headers";
 
+    /**
+     * Name of the <code>quoteall</code> connection property.
+     * false means only elements with the quote or escape character are quoted.
+     * Default value is true.
+     */
+    public static final String QUOTEALL = "quoteall";
+
     public CsvConnection(ConnectionParameters parameters) {
         super(Driver.DIALECT, new CsvConnectionParameters(parameters));
     }
@@ -95,6 +102,7 @@ public class CsvConnection extends AbstractTextConnection {
         final CsvConnectionParameters csvParams = getConnectionParameters();
         ParametersCallback formattingCallback = csvParams.getPropertyFormatter().format(parametersCallback);
         final boolean trimLines = csvParams.isTrimLines();
+        final boolean quoteall = csvParams.isQuoteall();
         PropertiesSubstitutor ps = new PropertiesSubstitutor(formattingCallback);
         for (String[] row; (row = reader.readNext()) != null;) {
             EtlCancelledException.checkEtlCancelled();
@@ -118,7 +126,7 @@ public class CsvConnection extends AbstractTextConnection {
                 }
             } else {
                 try {
-                    out.writeNext(row);
+                    out.writeNext(row, quoteall);
                     counter.statements++;
                 } catch (Exception e) {
                     throw new CsvProviderException("Failed to write CSV row ", e);

--- a/drivers/src/java/scriptella/driver/csv/CsvConnection.java
+++ b/drivers/src/java/scriptella/driver/csv/CsvConnection.java
@@ -38,7 +38,8 @@ import java.util.logging.Logger;
  * <p>For configuration details and examples see <a href="package-summary.html">overview page</a>.
  *
  * @author Fyodor Kupolov
- * @version 1.0
+ * @author Sean Summers
+ * @version 1.1
  */
 public class CsvConnection extends AbstractTextConnection {
     protected static final Logger LOG = Logger.getLogger(CsvConnection.class.getName());
@@ -56,6 +57,12 @@ public class CsvConnection extends AbstractTextConnection {
      * quoting.
      */
     public static final String QUOTE = "quote";
+    /**
+     * Name of the <code>escape</code> connection property.
+     * The character to use for escaped elements when writing to files. Use empty string to suppress
+     * escaping.
+     */
+    public static final String ESCAPE = "escape";
 
     /**
      * Name of the <code>headers</code> connection property.
@@ -155,7 +162,7 @@ public class CsvConnection extends AbstractTextConnection {
             final CsvConnectionParameters csvParams = getConnectionParameters();
             try {
                 writer = newOutputWriter();
-                out = new CSVWriter(writer, csvParams.getSeparator(), csvParams.getQuote(), csvParams.getEol());
+                out = new CSVWriter(writer, csvParams.getSeparator(), csvParams.getQuote(), csvParams.getEscape(), csvParams.getEol());
             } catch (IOException e) {
                 throw new CsvProviderException("Unable to open URL " + csvParams.getUrl() + " for output", e);
             }

--- a/drivers/src/java/scriptella/driver/csv/CsvConnectionParameters.java
+++ b/drivers/src/java/scriptella/driver/csv/CsvConnectionParameters.java
@@ -24,19 +24,23 @@ import scriptella.spi.ConnectionParameters;
  * Connection parameters for CSV driver
  *
  * @author Fyodor Kupolov
- * @version 1.1
+ * @author Sean Summers
+ * @version 1.2
  */
 public class CsvConnectionParameters extends TextConnectionParameters {
     public static final char DEFAULT_SEPARATOR = ',';
     public static final char DEFAULT_QUERY = '\"';
+    public static final char DEFAULT_ESCAPE = '\"';
     public static final boolean DEFAULT_HEADERS = true;
     protected char separator;
     protected char quote;
+    protected char escape;
     protected boolean headers;
 
     protected CsvConnectionParameters() {
         separator = DEFAULT_SEPARATOR;
         quote = DEFAULT_QUERY;
+        escape = DEFAULT_ESCAPE;
         headers = DEFAULT_HEADERS;
     }
 
@@ -56,6 +60,14 @@ public class CsvConnectionParameters extends TextConnectionParameters {
         } else { //otherwise no quoting
             quote = CSVWriter.NO_QUOTE_CHARACTER;
         }
+        String e = parameters.getStringProperty(CsvConnection.ESCAPE);
+        if (e == null) {
+            escape = DEFAULT_ESCAPE; //default value
+        } else if (e.length() > 0) {
+            escape = e.charAt(0);
+        } else { //otherwise no quoting
+            escape = CSVWriter.NO_ESCAPE_CHARACTER;
+        }
 
         headers = parameters.getBooleanProperty(CsvConnection.HEADERS, DEFAULT_HEADERS);
     }
@@ -68,6 +80,10 @@ public class CsvConnectionParameters extends TextConnectionParameters {
         return quote;
     }
 
+    public char getEscape() {
+        return escape;
+    }
+
     public boolean isHeaders() {
         return headers;
     }
@@ -78,6 +94,10 @@ public class CsvConnectionParameters extends TextConnectionParameters {
 
     public void setQuote(char quote) {
         this.quote = quote;
+    }
+
+    public void setEscape(char escape) {
+        this.escape = escape;
     }
 
     public void setHeaders(boolean headers) {

--- a/drivers/src/java/scriptella/driver/csv/CsvConnectionParameters.java
+++ b/drivers/src/java/scriptella/driver/csv/CsvConnectionParameters.java
@@ -32,16 +32,19 @@ public class CsvConnectionParameters extends TextConnectionParameters {
     public static final char DEFAULT_QUERY = '\"';
     public static final char DEFAULT_ESCAPE = '\"';
     public static final boolean DEFAULT_HEADERS = true;
+    public static final boolean DEFAULT_QUOTEALL = true;
     protected char separator;
     protected char quote;
     protected char escape;
     protected boolean headers;
+    protected boolean quoteall;
 
     protected CsvConnectionParameters() {
         separator = DEFAULT_SEPARATOR;
         quote = DEFAULT_QUERY;
         escape = DEFAULT_ESCAPE;
         headers = DEFAULT_HEADERS;
+        quoteall = DEFAULT_QUOTEALL;
     }
 
     public CsvConnectionParameters(ConnectionParameters parameters) {
@@ -70,6 +73,8 @@ public class CsvConnectionParameters extends TextConnectionParameters {
         }
 
         headers = parameters.getBooleanProperty(CsvConnection.HEADERS, DEFAULT_HEADERS);
+
+        quoteall = parameters.getBooleanProperty(CsvConnection.QUOTEALL, DEFAULT_QUOTEALL);
     }
 
     public char getSeparator() {
@@ -88,6 +93,10 @@ public class CsvConnectionParameters extends TextConnectionParameters {
         return headers;
     }
 
+    public boolean isQuoteall() {
+        return quoteall;
+    }
+
     public void setSeparator(char separator) {
         this.separator = separator;
     }
@@ -102,5 +111,9 @@ public class CsvConnectionParameters extends TextConnectionParameters {
 
     public void setHeaders(boolean headers) {
         this.headers = headers;
+    }
+
+    public void setQuoteall(boolean quoteall) {
+        this.quoteall = quoteall;
     }
 }

--- a/drivers/src/java/scriptella/driver/csv/opencsv/CSVWriter.java
+++ b/drivers/src/java/scriptella/driver/csv/opencsv/CSVWriter.java
@@ -24,6 +24,7 @@ import java.io.Writer;
  *
  * @author Glen Smith
  * @author Fyodor Kupolov
+ * @author Sean Summers
  *
  */
 public class CSVWriter implements Closeable {
@@ -34,10 +35,15 @@ public class CSVWriter implements Closeable {
 
     private char quotechar;
 
+    private char escapechar;
+
     private String lineEnd;
 
-    /** The character used for escaping quotes. */
-    public static final char ESCAPE_CHARACTER = '"';
+    /** The default character used for escaping quotes. */
+    public static final char DEFAULT_ESCAPE_CHARACTER = '"';
+
+    /** The escape constant to use when you wish to suppress all escaping. */
+    public static final char NO_ESCAPE_CHARACTER = '\u0000';
 
     /** The default separator to use if none is supplied to the constructor. */
     public static final char DEFAULT_SEPARATOR = ',';
@@ -87,7 +93,39 @@ public class CSVWriter implements Closeable {
      *            the character to use for quoted elements
      */
     public CSVWriter(Writer writer, char separator, char quotechar) {
-    	this(writer, separator, quotechar, "\n");
+    	this(writer, separator, quotechar, DEFAULT_ESCAPE_CHARACTER);
+    }
+
+    /**
+     * Constructs CSVWriter with supplied separator and quote char.
+     *
+     * @param writer
+     *            the writer to an underlying CSV source.
+     * @param separator
+     *            the delimiter to use for separating entries
+     * @param quotechar
+     *            the character to use for quoted elements
+     * @param escapechar
+     *            the character to use for escaping
+     */
+    public CSVWriter(Writer writer, char separator, char quotechar, char escapechar) {
+    	this(writer, separator, quotechar, escapechar, DEFAULT_LINE_END);
+    }
+
+    /**
+     * Constructs CSVWriter with supplied separator and quote char.
+     *
+     * @param writer
+     *            the writer to an underlying CSV source.
+     * @param separator
+     *            the delimiter to use for separating entries
+     * @param quotechar
+     *            the character to use for quoted elements
+     * @param escapechar
+     *            the character to use for escaping
+     */
+    public CSVWriter(Writer writer, char separator, char quotechar, String lineEnd) {
+    	this(writer, separator, quotechar, DEFAULT_ESCAPE_CHARACTER, lineEnd);
     }
 
     /**
@@ -102,13 +140,13 @@ public class CSVWriter implements Closeable {
      * @param lineEnd
      * 			  the line feed terminator to use
      */
-    public CSVWriter(Writer writer, char separator, char quotechar, String lineEnd) {
+    public CSVWriter(Writer writer, char separator, char quotechar, char escapechar, String lineEnd) {
         this.writer = writer;
         this.separator = separator;
         this.quotechar = quotechar;
+        this.escapechar = escapechar;
         this.lineEnd = lineEnd;
     }
-
 
     /**
      * Writes the next line to the file.
@@ -133,10 +171,8 @@ public class CSVWriter implements Closeable {
             final int length = nextElement.length(); //Kupolov: use local variable in a loop
             for (int j = 0; j < length; j++) {
                 char nextChar = nextElement.charAt(j);
-                if (nextChar == quotechar) {
-                    writer.append(ESCAPE_CHARACTER).append(nextChar);
-                } else if (nextChar == ESCAPE_CHARACTER) {
-                    writer.append(ESCAPE_CHARACTER).append(nextChar);
+                if (escapechar != NO_ESCAPE_CHARACTER && (nextChar == quotechar || nextChar == escapechar)) {
+                    writer.append(escapechar).append(nextChar);
                 } else {
                     writer.append(nextChar);
                 }

--- a/drivers/src/java/scriptella/driver/csv/opencsv/CSVWriter.java
+++ b/drivers/src/java/scriptella/driver/csv/opencsv/CSVWriter.java
@@ -164,14 +164,19 @@ public class CSVWriter implements Closeable {
             }
 
             String nextElement = nextLine[i];
-            if (nextElement == null)
+            if (nextElement == null) {
                 continue;
+            }
 
-            final Boolean hasSpecialCharacters =  nextElement.indexOf(quotechar) != -1 || nextElement.indexOf(escapechar) != -1 || nextElement.indexOf(separator) != -1 
-                                               || nextElement.contains(lineEnd) || nextElement.contains("\r");
+            final boolean hasSpecialCharacters =  nextElement.indexOf(quotechar) != -1 
+                                               || nextElement.indexOf(escapechar) != -1 
+                                               || nextElement.indexOf(separator) != -1 
+                                               || nextElement.contains(lineEnd)  
+                                               || nextElement.contains("\r");
 
-            if ((quoteall || hasSpecialCharacters) && (quotechar != NO_QUOTE_CHARACTER))
+            if ((quoteall || hasSpecialCharacters) && (quotechar != NO_QUOTE_CHARACTER)) {
             	writer.append(quotechar);
+            }
 
             if(!hasSpecialCharacters) {
                 writer.append(nextElement);
@@ -187,8 +192,9 @@ public class CSVWriter implements Closeable {
                 }
             }
 
-            if ((quoteall || hasSpecialCharacters) && (quotechar != NO_QUOTE_CHARACTER))
+            if ((quoteall || hasSpecialCharacters) && (quotechar != NO_QUOTE_CHARACTER)) {
             	writer.append(quotechar);
+            }
         }
 
         writer.append(lineEnd);

--- a/drivers/src/java/scriptella/driver/csv/opencsv/CSVWriter.java
+++ b/drivers/src/java/scriptella/driver/csv/opencsv/CSVWriter.java
@@ -156,7 +156,7 @@ public class CSVWriter implements Closeable {
      *            entry.
      * @throws java.io.IOException if I/O error occurs
      */
-    public void writeNext(String[] nextLine) throws IOException {
+    public void writeNext(String[] nextLine, boolean quoteall) throws IOException {
         final int colCount = nextLine.length;
         for (int i = 0; i < colCount; i++) {
             if (i != 0) {
@@ -166,18 +166,28 @@ public class CSVWriter implements Closeable {
             String nextElement = nextLine[i];
             if (nextElement == null)
                 continue;
-            if (quotechar != NO_QUOTE_CHARACTER)
+
+            final Boolean hasSpecialCharacters =  nextElement.indexOf(quotechar) != -1 || nextElement.indexOf(escapechar) != -1 || nextElement.indexOf(separator) != -1 
+                                               || nextElement.contains(lineEnd) || nextElement.contains("\r");
+
+            if ((quoteall || hasSpecialCharacters) && (quotechar != NO_QUOTE_CHARACTER))
             	writer.append(quotechar);
-            final int length = nextElement.length(); //Kupolov: use local variable in a loop
-            for (int j = 0; j < length; j++) {
-                char nextChar = nextElement.charAt(j);
-                if (escapechar != NO_ESCAPE_CHARACTER && (nextChar == quotechar || nextChar == escapechar)) {
-                    writer.append(escapechar).append(nextChar);
-                } else {
-                    writer.append(nextChar);
+
+            if(!hasSpecialCharacters) {
+                writer.append(nextElement);
+            } else {
+                final int length = nextElement.length(); //Kupolov: use local variable in a loop
+                for (int j = 0; j < length; j++) {
+                    char nextChar = nextElement.charAt(j);
+                    if (escapechar != NO_ESCAPE_CHARACTER && (nextChar == quotechar || nextChar == escapechar)) {
+                        writer.append(escapechar).append(nextChar);
+                    } else {
+                        writer.append(nextChar);
+                    }
                 }
             }
-            if (quotechar != NO_QUOTE_CHARACTER)
+
+            if ((quoteall || hasSpecialCharacters) && (quotechar != NO_QUOTE_CHARACTER))
             	writer.append(quotechar);
         }
 

--- a/drivers/src/test/scriptella/driver/csv/CsvConnectionTest.java
+++ b/drivers/src/test/scriptella/driver/csv/CsvConnectionTest.java
@@ -78,6 +78,7 @@ public class CsvConnectionTest extends AbstractTestCase {
         props.put(CsvConnection.EOL, "\r\n");
         props.put(CsvConnection.HEADERS, "false");
         props.put(CsvConnection.QUOTE, "'");
+        props.put(CsvConnection.ESCAPE, "\\");
         props.put(CsvConnection.SEPARATOR, ";");
         ConnectionParameters cp = new MockConnectionParameters(props, "tst://file");
 
@@ -127,6 +128,22 @@ public class CsvConnectionTest extends AbstractTestCase {
                 MockParametersCallbacks.SIMPLE);
         con.close();
         String expected = "*row1*;value;value\r\n*row2*;;value\u0394\r\n";
+        String actual = out.toString("UTF8");
+        assertEquals(expected, actual);
+    }
+
+    public void testEscape() throws UnsupportedEncodingException {
+        Map<String, String> props = new HashMap<String, String>();
+        props.put(CsvConnection.ESCAPE, "'");
+        ConnectionParameters cp = new MockConnectionParameters(props, "tst://file");
+
+        CsvConnection con = new CsvConnection(cp);
+        //register handler for tst url
+        rows = 0;
+        con.executeScript(new StringResource("  $row1,\"value\",val${'ue'}\n$row2,'value',va'l'ue\n"),
+                MockParametersCallbacks.SIMPLE);
+        con.close();
+        String expected = "\"*row1*\",\"value\",\"value\"\n\"*row2*\",\"''value''\",\"va''l''ue\"\n";
         String actual = out.toString("UTF8");
         assertEquals(expected, actual);
     }

--- a/drivers/src/test/scriptella/driver/csv/CsvConnectionTest.java
+++ b/drivers/src/test/scriptella/driver/csv/CsvConnectionTest.java
@@ -148,6 +148,22 @@ public class CsvConnectionTest extends AbstractTestCase {
         assertEquals(expected, actual);
     }
 
+    public void testQuoteall() throws UnsupportedEncodingException {
+        Map<String, String> props = new HashMap<String, String>();
+        props.put(CsvConnection.QUOTEALL, "false");
+        ConnectionParameters cp = new MockConnectionParameters(props, "tst://file");
+
+        CsvConnection con = new CsvConnection(cp);
+        //register handler for tst url
+        rows = 0;
+        con.executeScript(new StringResource("  $row1,va\"l\"ue,val${'ue'}\n$row2,'value',va\"l\"ue\n"),
+                MockParametersCallbacks.SIMPLE);
+        con.close();
+        String expected = "*row1*,\"va\"\"l\"\"ue\",value\n*row2*,'value',\"va\"\"l\"\"ue\"\n";
+        String actual = out.toString("UTF8");
+        assertEquals(expected, actual);
+    }
+
     /**
      * Tests CSV processing with trim mode switched off.
      */


### PR DESCRIPTION
Added escape= (defaults to \" per status quo) to change the default escape character.

Added quoteall= (defaults to true per status quo) to allow quoting only fields with an embedded escape, LINE_END or \r character.

(used current opencsv to inform the patches, as suggested)

fixes #11 