### PR TITLE
Add source and target to parent project.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
+		<configuration>
+			<source>1.7</source>
+			<target>1.7</target>
+		</configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
I added source and target settings for the Maven compiler to indicate
the target version level of the software.  There are not many changes
necessary to get scriptella to JDK8 compliance, but indicating the
current version will allow that support to be specifically targeted
as a goal for the project while fixing compile errors that occur in
eclipse in the meantime.
